### PR TITLE
When adding Water, check for Water, not LqdWater

### DIFF
--- a/GameData/WarpPlugin/Resources/RealFuelsFix.cfg
+++ b/GameData/WarpPlugin/Resources/RealFuelsFix.cfg
@@ -8,7 +8,7 @@
 }
 
 //Add water tank using KSPI water. (TO-DO: integration with TACLS water without trampling KSPI or TACLS)
-@TANK_DEFINITION[*]:FINAL:HAS[@TANK[Kerosene],!TANK[LqdWater]]:NEEDS[RealFuels]:FOR[WarpPlugin]
+@TANK_DEFINITION[*]:FINAL:HAS[@TANK[Kerosene],!TANK[Water]]:NEEDS[RealFuels]:FOR[WarpPlugin]
 {
     +TANK[Kerosene]
     {


### PR DESCRIPTION
The way it was would cause a duplicate Water entry in ServiceModule tanks, which caused RF to error when loading tank types. This resulted in all MFT tanks being unable to contain anything.
