### PR TITLE
Typo, engine RF support

### DIFF
--- a/GameData/WarpPlugin/Resources/RealFuelsFix.cfg
+++ b/GameData/WarpPlugin/Resources/RealFuelsFix.cfg
@@ -146,7 +146,7 @@
 }
 @BASIC_NTR_PROPELLANT[Methalox]:FINAL:NEEDS[RealFuels]:FOR[WarpPlugin]
 {
-    @PROPELLANT[Oxidizier]
+    @PROPELLANT[Oxidizer]
     {
         @name = LqdOxygen
         @ratio = 0.557
@@ -222,6 +222,28 @@
     @MODULE[FNModuleResourceExtraction]:HAS[#resourceName[Ammonia]]
     {
         @resourceName = LqdAmmonia
+    }
+}
+
+@PART[TweakableMagneticNozzle,KSPIMagneticNozzle*]:NEEDS[RealFuels]:FOR[WarpPlugin] // Magnetic Nozzle
+{
+    @MODULE[ModuleEnginesFX]
+    {
+	@PROPELLANT[LiquidFuel]
+	{
+	    @name = LqdHydrogen
+	}
+    }
+}
+
+@PART[FNMethaneEngine]:NEEDS[RealFuels]:FOR[WarpPlugin] // Deinonychus 1-D
+{
+    @MODULE[ModuleEngines]
+    {
+	@PROPELLANT[Oxidizer]
+	{
+	    @name = LqdOxygen
+	}
     }
 }
 

--- a/GameData/WarpPlugin/Resources/RealFuelsFix.cfg
+++ b/GameData/WarpPlugin/Resources/RealFuelsFix.cfg
@@ -236,17 +236,6 @@
     }
 }
 
-@PART[FNMethaneEngine]:NEEDS[RealFuels]:FOR[WarpPlugin] // Deinonychus 1-D
-{
-    @MODULE[ModuleEngines]
-    {
-	@PROPELLANT[Oxidizer]
-	{
-	    @name = LqdOxygen
-	}
-    }
-}
-
 //NOTE: the ratio might be kinda screwy; this should really go in an engines config.
 @PART[AluminiumHybrid1]:FINAL:NEEDS[RealFuels]:FOR[WarpPlugin]
 {


### PR DESCRIPTION
- Fixed typo among BASIC_NTR_PROPELLANT configs
- Real Fuels resources for Magnetic Nozzle, Deinonychus 1-D

Gave the Magnetic Nozzle LqdHydrogen as propellant. Not sure if this is correct.

For your consideration.
