### PR TITLE
Near Future mode "upgradedRadiatorArea"

### DIFF
--- a/GameData/WarpPlugin/Techtree/USI_NF_Mode.cfg
+++ b/GameData/WarpPlugin/Techtree/USI_NF_Mode.cfg
@@ -138,6 +138,7 @@
 	@MODULE[FNRadiator]
 	{
 		@radiatorArea *= 0.002
+		@upgradedRadiatorArea *= 0.002
 	}
 
 	@RESOURCE[WasteHeat]


### PR DESCRIPTION
"upgradedRadiatorArea" should be nerfed along with "radiatorArea" when KSPI runs in NF mode. If not, upgraded radiators become wildly unbalanced.
