### PR TITLE
Updated USI_NF_Mode to play nicer with SETI

### DIFF
--- a/GameData/WarpPlugin/Patches/USI_NF_Mode.cfg
+++ b/GameData/WarpPlugin/Patches/USI_NF_Mode.cfg
@@ -1,4 +1,4 @@
-@PART[*]:HAS[@MODULE[FNModuleCryostat]]:NEEDS[NearFutureElectrical|SETI]:FOR[WarpPlugin]
+@PART[*]:HAS[@MODULE[FNModuleCryostat]]:NEEDS[NearFutureElectrical]:FOR[WarpPlugin]
 {
 	@MODULE[FNGenerator]
 	{
@@ -6,7 +6,7 @@
 	}
 }
 
-@PART[*]:HAS[@MODULE[FNModuleCryostat]]:NEEDS[NearFutureElectrical|SETI]:FOR[WarpPlugin]
+@PART[*]:HAS[@MODULE[FNModuleCryostat]]:NEEDS[NearFutureElectrical]:FOR[WarpPlugin]
 {
 	@MODULE[FNModuleCryostat],*
 	{
@@ -14,7 +14,7 @@
 	}
 }
 
-@PART[*]:HAS[@MODULE[ISRUScoop]]:NEEDS[NearFutureElectrical|SETI]:FOR[WarpPlugin]
+@PART[*]:HAS[@MODULE[ISRUScoop]]:NEEDS[NearFutureElectrical]:FOR[WarpPlugin]
 {
 	@MODULE[ISRUScoop]
 	{
@@ -23,7 +23,7 @@
 }
 
 
-@PART[*]:HAS[@MODULE[MicrowavePowerReceiver]]:NEEDS[NearFutureElectrical|SETI]:FOR[WarpPlugin]
+@PART[*]:HAS[@MODULE[MicrowavePowerReceiver]]:NEEDS[NearFutureElectrical]:FOR[WarpPlugin]
 {
 	@MODULE[MicrowavePowerReceiver]
 	{
@@ -31,7 +31,7 @@
 	}
 }
 
-@PART[*]:HAS[@MODULE[InterstellarFissionPBDP]]:NEEDS[NearFutureElectrical|SETI]:FOR[WarpPlugin]
+@PART[*]:HAS[@MODULE[InterstellarFissionPBDP]]:NEEDS[NearFutureElectrical]:FOR[WarpPlugin]
 {
 	@MODULE[InterstellarFissionPBDP]
 	{
@@ -44,7 +44,7 @@
 	}
 }
 
-@PART[*]:HAS[@MODULE[InterstellarFissionNTR]]:NEEDS[NearFutureElectrical|SETI]:FOR[WarpPlugin]
+@PART[*]:HAS[@MODULE[InterstellarFissionNTR]]:NEEDS[NearFutureElectrical]:FOR[WarpPlugin]
 {
 	@MODULE[InterstellarFissionNTR]
 	{
@@ -55,7 +55,7 @@
 	}
 }
 
-@PART[*]:HAS[@MODULE[InterstellarFissionMSRGC]]:NEEDS[NearFutureElectrical|SETI]:FOR[WarpPlugin]
+@PART[*]:HAS[@MODULE[InterstellarFissionMSRGC]]:NEEDS[NearFutureElectrical]:FOR[WarpPlugin]
 {
 	@MODULE[InterstellarFissionMSRGC]
 	{
@@ -66,7 +66,7 @@
 	}
 }
 
-@PART[*]:HAS[@MODULE[InterstellarTokamakFusionReactor]]:NEEDS[NearFutureElectrical|SETI]:FOR[WarpPlugin]
+@PART[*]:HAS[@MODULE[InterstellarTokamakFusionReactor]]:NEEDS[NearFutureElectrical]:FOR[WarpPlugin]
 {
 	@MODULE[InterstellarTokamakFusionReactor]
 	{
@@ -77,7 +77,7 @@
 	}
 }
 
-@PART[*]:HAS[@MODULE[InterstellarInertialConfinementReactor]]:NEEDS[NearFutureElectrical|SETI]:FOR[WarpPlugin]
+@PART[*]:HAS[@MODULE[InterstellarInertialConfinementReactor]]:NEEDS[NearFutureElectrical]:FOR[WarpPlugin]
 {
 	@MODULE[InterstellarInertialConfinementReactor]
 	{
@@ -88,7 +88,7 @@
 	}
 }
 
-@PART[*]:HAS[@MODULE[InterstellarCatalysedFissionFusion]]:NEEDS[NearFutureElectrical|SETI]:FOR[WarpPlugin]
+@PART[*]:HAS[@MODULE[InterstellarCatalysedFissionFusion]]:NEEDS[NearFutureElectrical]:FOR[WarpPlugin]
 {
 	@MODULE[InterstellarCatalysedFissionFusion]
 	{
@@ -100,7 +100,7 @@
 	}
 }
 
-@PART[*]:HAS[@MODULE[FNAntimatterReactor]]:NEEDS[NearFutureElectrical|SETI]:FOR[WarpPlugin]
+@PART[*]:HAS[@MODULE[FNAntimatterReactor]]:NEEDS[NearFutureElectrical]:FOR[WarpPlugin]
 {
 	@MODULE[FNAntimatterReactor]
 	{
@@ -113,7 +113,7 @@
 }
 
 //***** Radiators *****
-@PART[*]:HAS[@MODULE[FNRadiator]]:NEEDS[NearFutureElectrical|SETI]:FOR[WarpPlugin]
+@PART[*]:HAS[@MODULE[FNRadiator]]:NEEDS[NearFutureElectrical]:FOR[WarpPlugin]
 {
 	@MODULE[FNRadiator]
 	{
@@ -125,7 +125,7 @@
 
 
 //***** Thermal Noozles *****
-@PART[*]:HAS[@MODULE[ThermalNozzleController]]:NEEDS[NearFutureElectrical|SETI]:FOR[WarpPlugin]
+@PART[*]:HAS[@MODULE[ThermalNozzleController]]:NEEDS[NearFutureElectrical]:FOR[WarpPlugin]
 {
 	@MODULE[ThermalNozzleController]
 	{
@@ -134,7 +134,7 @@
 	}
 }
 
-@PART[*]:HAS[@MODULE[InterstellarMagneticNozzleControllerFX]]:NEEDS[NearFutureElectrical|SETI]:FOR[WarpPlugin]
+@PART[*]:HAS[@MODULE[InterstellarMagneticNozzleControllerFX]]:NEEDS[NearFutureElectrical]:FOR[WarpPlugin]
 {
 	@MODULE[InterstellarMagneticNozzleControllerFX]
 	{
@@ -144,7 +144,7 @@
 }
 
 //** Electric Engines ***
-@PART[*]:HAS[@MODULE[ElectricEngineControllerFX]]:NEEDS[NearFutureElectrical|SETI]:FOR[WarpPlugin]
+@PART[*]:HAS[@MODULE[ElectricEngineControllerFX]]:NEEDS[NearFutureElectrical]:FOR[WarpPlugin]
 {
 	@MODULE[ElectricEngineControllerFX]
 	{
@@ -155,7 +155,7 @@
 }
 
 //**** Fusion Engines ****
-@PART[*]:HAS[@MODULE[VistaEngineControllerAdvanced]]:NEEDS[NearFutureElectrical|SETI]:FOR[WarpPlugin]
+@PART[*]:HAS[@MODULE[VistaEngineControllerAdvanced]]:NEEDS[NearFutureElectrical]:FOR[WarpPlugin]
 {
 	@MODULE[VistaEngineControllerAdvanced]
 	{
@@ -165,7 +165,7 @@
 }
 
 //**** Fusion Engines ****
-@PART[*]:HAS[@MODULE[VistaEngineController]]:NEEDS[NearFutureElectrical|SETI]:FOR[WarpPlugin]
+@PART[*]:HAS[@MODULE[VistaEngineController]]:NEEDS[NearFutureElectrical]:FOR[WarpPlugin]
 {
 	@MODULE[VistaEngineController]
 	{
@@ -175,7 +175,7 @@
 }
 
 //****** Refineries *****
-@PART[*]:HAS[@MODULE[InterstellarRefinery]]:NEEDS[NearFutureElectrical|SETI]:FOR[WarpPlugin]
+@PART[*]:HAS[@MODULE[InterstellarRefinery]]:NEEDS[NearFutureElectrical]:FOR[WarpPlugin]
 {
 	@MODULE[InterstellarRefinery]
 	{
@@ -183,7 +183,7 @@
 	}
 }
 
-@PART[*]:HAS[@MODULE[FNModuleResourceExtraction]]:NEEDS[NearFutureElectrical|SETI]:FOR[WarpPlugin]
+@PART[*]:HAS[@MODULE[FNModuleResourceExtraction]]:NEEDS[NearFutureElectrical]:FOR[WarpPlugin]
 {
 	@MODULE[FNModuleResourceExtraction],0
 	{
@@ -223,13 +223,10 @@
 }
 
 //**** Science ***
-@PART[*]:HAS[@MODULE[ScienceModule]]:NEEDS[NearFutureElectrical|SETI]:FOR[WarpPlugin]
+@PART[*]:HAS[@MODULE[ScienceModule]]:NEEDS[NearFutureElectrical]:FOR[WarpPlugin]
 {
 	@MODULE[ScienceModule]
 	{
 		%powerReqMult = 0.02
 	}
 }
-
-
-


### PR DESCRIPTION
SETI/rebalance/ctt now appears to primarily modify costs and some mass for existing (and a handful of reskinned) props, but it doesn't do anything with power consumption.  The SETI electrics section primarily deals with TweakScale values and cost.  We probably shouldn't mess with electrical values unless something like NearFutureElectrical adds more parts.

In addition it looks like the SETI module manager flag is depreciated so it shouldn't be used anyway.  The only thing that still sets it is the SETI community tech tree and that just moves things around.
